### PR TITLE
Update library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,5 +17,5 @@
   ],
   "version": "2.2.5",
   "frameworks": "arduino",
-  "platforms": "espressif"
+  "platforms": ["espressif8266", "espressif32"]
 }


### PR DESCRIPTION
Change plattforms code to use the newer specifications instead of the old one. Old one will have problems in plattform.io with strict mode (https://community.platformio.org/t/library-asyncelegantota-header-from-lib-not-found/20959).