### PR TITLE
Restart fix and simplify

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ void setup(void) {
 }
 
 void loop(void) {
-  AsyncElegantOTA.loop();
 }
 
 ```
@@ -176,7 +175,6 @@ void setup(void) {
 }
 
 void loop(void) {
-  AsyncElegantOTA.loop();
 }
 
 ```

--- a/examples/ESP32_Async_Demo/ESP32_Async_Demo.ino
+++ b/examples/ESP32_Async_Demo/ESP32_Async_Demo.ino
@@ -36,5 +36,4 @@ void setup(void) {
 }
 
 void loop(void) {
-  AsyncElegantOTA.loop();
 }

--- a/examples/ESP8266_Async_Demo/ESP8266_Async_Demo.ino
+++ b/examples/ESP8266_Async_Demo/ESP8266_Async_Demo.ino
@@ -36,5 +36,4 @@ void setup(void) {
 }
 
 void loop(void) {
-  AsyncElegantOTA.loop();
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,3 +1,2 @@
 AsyncElegantOTA	KEYWORD1
 begin	KEYWORD2
-loop	KEYWORD2

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -1,7 +1,7 @@
-#warning AsyncElegantOTA.loop(); is deprecated, please remove it from loop()
-
 #ifndef AsyncElegantOTA_h
 #define AsyncElegantOTA_h
+
+#warning AsyncElegantOTA.loop(); is deprecated, please remove it from loop() if defined. This function will be removed in a future release.
 
 #include "Arduino.h"
 #include "stdlib_noniso.h"

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -81,7 +81,7 @@ class AsyncElegantOtaClass{
                 response->addHeader("Connection", "close");
                 response->addHeader("Access-Control-Allow-Origin", "*");
                 request->send(response);
-                restartRequired = true;
+                restart();
             }, [&](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
                 //Upload handler chunks in data
                 if(_authRequired){
@@ -132,20 +132,11 @@ class AsyncElegantOtaClass{
             });
         }
 
-        void loop(){
-            if(restartRequired){
-                yield();
-                delay(1000);
-                yield();
-                #if defined(ESP8266)
-                    ESP.restart();
-                #elif defined(ESP32)
-                    // ESP32 will commit sucide
-                    esp_task_wdt_init(1,true);
-                    esp_task_wdt_add(NULL);
-                    while(true);
-                #endif
-            }
+        void restart(){
+            yield();
+            delay(1000);
+            yield();
+            ESP.restart();
         }
 
     private:
@@ -166,7 +157,6 @@ class AsyncElegantOtaClass{
         String _username = "";
         String _password = "";
         bool _authRequired = false;
-        bool restartRequired = false;
 
 };
 

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -1,3 +1,5 @@
+#warning AsyncElegantOTA.loop(); is deprecated, please remove it from loop()
+
 #ifndef AsyncElegantOTA_h
 #define AsyncElegantOTA_h
 

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -132,7 +132,11 @@ class AsyncElegantOtaClass{
             });
         }
 
-        void restart(){
+        // deprecated, keeping for backward compatibility
+        void loop() {
+        }
+        
+        void restart() {
             yield();
             delay(1000);
             yield();


### PR DESCRIPTION
Was looking into the restart issue #44 ... and came up with thinking there is no point in having the loop() method. Might be some kind of best practice but on the other hand KISS and YAGNI. And I also think this is the perfect answer to #56 

Then my ESP32 perfectly resets with `ESP.restart();` - so I don't know for sure if the used suicide method is obsolete or my ESP32 is different?