### PR TITLE
Added Pre OTA Update Callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Download the [Repository](https://github.com/ayushsharma82/AsyncElegantOTA/archi
 
 <b>Antivirus Issue:</b> If you have an antivirus on your PC with internet security, the progress bar on webpage will instantly show 100% because of request caching by your antivirus software. There is no fix for this unless you want to disable your antivirus or whitelist your local IP addresses in it. ( Same is the case with iOS, safari will cache the outgoing requests )
 
-<br>
+
+ #### Pre Update Callback Binding (optional):
+ If you want to run some task like disabling some piece of code that comes in the way of the OTA update and causes some panic, just put  `AsyncElegantOTA.preFotaRoutineCallback(callback);` in the setup(), which binds the callback and calls it just before an OTA update begins. Callback declaration should only be `void callback(void);`.
 
 <h2>Tutorials</h2>
 <p>Tutorials for AsyncElegantOTA is live on RandomNerdTutorials.</p>
@@ -182,7 +184,7 @@ void loop(void) {
 <br>
 
 <h2>Contributions</h2>
-<p>Every Contribution to this repository is highly appriciated! Don't fear to create pull requests which enhance or fix the library as ultimatly you are going to help everybody.</p>
+<p>Every Contribution to this repository is highly appriciated! Don't fear to create pull requests which enhance or fix the library as ultimately you are going to help everybody.</p>
 <p>
 If you want to donate to the author then <b>you can buy me a coffee</b>, It really helps me keep these libraries updated:
 <br/><br/>

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,2 +1,3 @@
 AsyncElegantOTA	KEYWORD1
 begin	KEYWORD2
+preFotaRoutineCallback KEYWORD2

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -61,7 +61,6 @@ class AsyncElegantOtaClass{
             });
 
             _server->on("/update", HTTP_GET, [&](AsyncWebServerRequest *request){
-                preUpdateCallback(); 
                 if(_authRequired){
                     if(!request->authenticate(_username.c_str(), _password.c_str())){
                         return request->requestAuthentication();
@@ -101,7 +100,7 @@ class AsyncElegantOtaClass{
                     if(!Update.setMD5(request->getParam("MD5", true)->value().c_str())) {
                         return request->send(400, "text/plain", "MD5 parameter invalid");
                     }
-
+                    preUpdateCallback();
                     #if defined(ESP8266)
                         int cmd = (filename == "filesystem") ? U_FS : U_FLASH;
                         Update.runAsync(true);

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -61,6 +61,7 @@ class AsyncElegantOtaClass{
             });
 
             _server->on("/update", HTTP_GET, [&](AsyncWebServerRequest *request){
+                preUpdateCallback(); 
                 if(_authRequired){
                     if(!request->authenticate(_username.c_str(), _password.c_str())){
                         return request->requestAuthentication();
@@ -145,6 +146,10 @@ class AsyncElegantOtaClass{
             ESP.restart();
         }
 
+        void preFotaRoutineCallback(void callable(void)){
+            preUpdateCallback = callable;
+        }
+
     private:
         AsyncWebServer *_server;
 
@@ -163,6 +168,7 @@ class AsyncElegantOtaClass{
         String _username = "";
         String _password = "";
         bool _authRequired = false;
+        void (*preUpdateCallback)();
 
 };
 


### PR DESCRIPTION
If someone needs to run some code just before the update begins, it can be done by adding the line: `AsyncElegantOTA.preFotaRoutineCallback(callback);` to the setup. All the instructions are written under Documentation in [README](readme.md)
Tested this with ESP8266 as well as ESP32, works on both.