### PR TITLE
PlatformIO workflow upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,18 +73,27 @@ Download the [Repository](https://github.com/ayushsharma82/AsyncElegantOTA/archi
 <h3>ESP8266</h3> 
 <h4>Arduino IDE:</h4>
 <p>https://randomnerdtutorials.com/esp8266-nodemcu-ota-over-the-air-arduino/</p>
-<h4>PlatformIO:</h4>
+<h4>PlatformIO (manual method):</h4>
 <p>https://randomnerdtutorials.com/esp8266-nodemcu-ota-over-the-air-vs-code/</p>
 <br>
 
 <h3>ESP32</h3>
 <h4>Arduino IDE:</h4>
 <p>https://randomnerdtutorials.com/esp32-ota-over-the-air-arduino/</p>
-<h4>PlatformIO:</h4>
+<h4>PlatformIO (manual method):</h4>
 <p>https://randomnerdtutorials.com/esp32-ota-over-the-air-vs-code/</p>
-
 <br>
- 
+<h3>PlatformIO Automatic Method</h3>
+<ul>
+<li> Copy the file "platformio_upload.py" from this repository into the same folder as your platformio.ini file
+<li> Set the upload method for your project in platformio.ini:
+</ul>
+
+```
+extra_scripts = platformio_upload.py
+upload_protocol = custom
+upload_url = <your upload URL, such as http://192.168.1.123/update>
+``` 
 <br>
 <h2>Examples</h2>
  

--- a/platformio_upload.py
+++ b/platformio_upload.py
@@ -1,0 +1,53 @@
+# Allows PlatformIO to upload directly to AsyncElegantOTA
+#
+# To use:
+# - copy this script into the same folder as your platformio.ini
+# - set the following for your project in platformio.ini:
+#
+# extra_scripts = platformio_upload.py
+# upload_protocol = custom
+# upload_url = <your upload URL>
+# 
+# An example of an upload URL:
+# upload_URL = http://192.168.1.123/update
+
+import requests
+import hashlib
+Import('env')
+
+try:
+    from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+    from tqdm import tqdm
+except ImportError:
+    env.Execute("$PYTHONEXE -m pip install requests_toolbelt")
+    env.Execute("$PYTHONEXE -m pip install tqdm")
+    from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
+    from tqdm import tqdm
+
+def on_upload(source, target, env):
+    firmware_path = str(source[0])
+    upload_url = env.GetProjectOption('upload_url')
+
+    with open(firmware_path, 'rb') as firmware:
+        md5 = hashlib.md5(firmware.read()).hexdigest()
+        firmware.seek(0)
+        encoder = MultipartEncoder(fields={
+            'MD5': md5, 
+            'firmware': ('firmware', firmware, 'application/octet-stream')}
+        )
+
+        bar = tqdm(desc='Upload Progress',
+              total=encoder.len,
+              dynamic_ncols=True,
+              unit='B',
+              unit_scale=True,
+              unit_divisor=1024
+              )
+
+        monitor = MultipartEncoderMonitor(encoder, lambda monitor: bar.update(monitor.bytes_read - bar.n))
+
+        response = requests.post(upload_url, data=monitor, headers={'Content-Type': monitor.content_type})
+        bar.close()
+        print(response,response.text)
+            
+env.Replace(UPLOADCMD=on_upload)


### PR DESCRIPTION
Add a script that allows the PlatformIO upload command to write firmware directly to a device running AsyncElegantOTA.

This is a fair bit nicer to work with as compared to building in PlatformIO and then having to update separately via an external web interface.