### PR TITLE
ESP32: reset watchdog timer during update

### DIFF
--- a/src/AsyncElegantOTA.cpp
+++ b/src/AsyncElegantOTA.cpp
@@ -80,6 +80,8 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
                 uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
                 if (!Update.begin((cmd == U_FS)?fsSize:maxSketchSpace, cmd)){ // Start with max available size
             #elif defined(ESP32)
+                // Increase watchdog timer to avoid panic
+                esp_task_wdt_init(15, 0);
                 int cmd = (filename == "filesystem") ? U_SPIFFS : U_FLASH;
                 if (!Update.begin(UPDATE_SIZE_UNKNOWN, cmd)) { // Start with max available size
             #endif


### PR DESCRIPTION
Without this change, updates consistently fail because the watchdog causes a panic (see https://github.com/espressif/arduino-esp32/issues/3775, where similar behaviour is reported.)

```
E (20871) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (20871) task_wdt:  - IDLE (CPU 0)
E (20871) task_wdt: Tasks currently running:
E (20871) task_wdt: CPU 0: ipc0
E (20871) task_wdt: CPU 1: loopTask
E (20871) task_wdt: Aborting.
```

With this change, OTA updates complete as expected.