### PR TITLE
Fix ESP32-S2 restart

### DIFF
--- a/src/AsyncElegantOTA.cpp
+++ b/src/AsyncElegantOTA.cpp
@@ -111,10 +111,19 @@ void AsyncElegantOtaClass::loop() {
 }
 
 void AsyncElegantOtaClass::restart() {
-    yield();
-    delay(1000);
-    yield();
-    ESP.restart();
+    #if defined CONFIG_IDF_TARGET_ESP32S2 || defined CONFIG_IDF_TARGET_ESP32S2
+        yield();
+        delay(1000);
+        yield();
+        esp_task_wdt_init(1,true);
+        esp_task_wdt_add(NULL);
+        while(true);
+    #else
+        yield();
+        delay(1000);
+        yield();
+        ESP.restart();
+    #endif
 }
 
 String AsyncElegantOtaClass::getID(){


### PR DESCRIPTION
Hello!

I have been using ESP32-S2 with the AsyncElegantOTA library and other libraries (for example esptinyusb). 

I have identified that when updating the firmware with AsyncElegantOTA, ESP32-S2 goes into download mode on reboot (This only happens if I use other libraries, if I use the basic AsyncElegantOTA example this does not happen). Attached is an image:

![Selección_072](https://user-images.githubusercontent.com/27963913/185377106-82867fad-38c4-416b-be7e-b6b5b814ba5d.png)

ESP32-S2 does not reboot properly and does not run the new firmware. You have to physically disconnect and reconnect the ESP32S2 from the computer. 

To fix this I have modified AsyncElegantOtaClass::restart in AsyncElegantOta.cpp to force ESP32-S2 to properly restart and run the new firmware after the restart. Maybe there is another cleaner solution, but my modification causes ESP32-S2 to be restarted without entering download mode:

![Selección_073](https://user-images.githubusercontent.com/27963913/185378180-ea3406e4-d83b-4a47-b596-c28a43e2d0b4.png)

Thanks!