### PR TITLE
Added optional OTA start, progress and end callback

### DIFF
--- a/examples/Async_Callback_Demo/Async_Callback_Demo.ino
+++ b/examples/Async_Callback_Demo/Async_Callback_Demo.ino
@@ -24,19 +24,21 @@ const char* password = "........";
 AsyncWebServer server(80);
 
 int iCallBackCount = 0;
+unsigned long lStartTime ;
 
 void MyAction_onOTAStart() {
   iCallBackCount = 0;
-  Serial.printf("OTA update started %d\n\r", millis());
+  Serial.printf("OTA update started\n\r");
+  lStartTime = millis();
 }
 
 void  MyAction_onOTAProgress() {
   iCallBackCount = iCallBackCount + 1;
-  Serial.printf("OTA progress %d\n\r", millis());
+  Serial.printf("OTA progress, %5.3fs elapsed\n\r", (float)(millis()-lStartTime)/1000.0);
 }
 
 void MyAction_onOTAEnd() {
-  Serial.printf("OTA update ended %d\n\r", millis());
+  Serial.printf("OTA update ended, %5.3fs elapsed\n\r", (float)(millis()-lStartTime)/1000.0);
   iCallBackCount = 0 ;
 }
 

--- a/examples/Async_Callback_Demo/Async_Callback_Demo.ino
+++ b/examples/Async_Callback_Demo/Async_Callback_Demo.ino
@@ -1,0 +1,79 @@
+ /*
+  AsyncElegantOTA Callback Demo Example - This example will work for both ESP8266 & ESP32 microcontrollers.
+  -----
+  Author: Ayush Sharma ( https://github.com/ayushsharma82 )
+  
+  Important Notice: Star the repository on Github if you like the library! :)
+  Repository Link: https://github.com/ayushsharma82/AsyncElegantOTA
+*/
+
+#if defined(ESP8266)
+  #include <ESP8266WiFi.h>
+  #include <ESPAsyncTCP.h>
+#elif defined(ESP32)
+  #include <WiFi.h>
+  #include <AsyncTCP.h>
+#endif
+
+#include <ESPAsyncWebServer.h>
+#include <AsyncElegantOTA.h>
+
+const char* ssid = "........";
+const char* password = "........";
+
+AsyncWebServer server(80);
+
+int iCallBackCount = 0;
+
+void MyAction_onOTAStart() {
+  iCallBackCount = 0;
+  Serial.printf("OTA update started %d\n\r", millis());
+}
+
+void  MyAction_onOTAProgress() {
+  iCallBackCount = iCallBackCount + 1;
+  Serial.printf("OTA progress %d\n\r", millis());
+}
+
+void MyAction_onOTAEnd() {
+  Serial.printf("OTA update ended %d\n\r", millis());
+  iCallBackCount = 0 ;
+}
+
+void setup(void) {
+  Serial.begin(115200);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+  Serial.println("");
+
+  // Wait for connection
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+  Serial.println("");
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.print("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
+    request->send(200, "text/plain", "Hi! This is a sample response.");
+  });
+
+  AsyncElegantOTA.begin(&server);    // Start AsyncElegantOTA
+    server.begin();
+  Serial.println("HTTP server started");
+
+// Add the AsyncElegantOTA callbacks
+// Not all are required you can add each callback individually
+//
+// Watch the output on the serial monitor during OTA update.
+  AsyncElegantOTA.onOTAStart(MyAction_onOTAStart);
+  AsyncElegantOTA.onOTAProgress(MyAction_onOTAProgress);
+  AsyncElegantOTA.onOTAEnd(MyAction_onOTAEnd);
+
+}
+
+void loop(void) {
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,2 +1,3 @@
 AsyncElegantOTA	KEYWORD1
-begin	KEYWORD2
+begin		KEYWORD2
+onOTAStart	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,3 +1,5 @@
 AsyncElegantOTA	KEYWORD1
 begin		KEYWORD2
 onOTAStart	KEYWORD2
+onOTAEnd	KEYWORD2
+onOTAProgress	KEYWORD2

--- a/src/AsyncElegantOTA.cpp
+++ b/src/AsyncElegantOTA.cpp
@@ -73,6 +73,8 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
                 return request->send(400, "text/plain", "MD5 parameter invalid");
             }
 
+            if (_preUpdateRequired) preUpdateCallback();
+
             #if defined(ESP8266)
                 int cmd = (filename == "filesystem") ? U_FS : U_FLASH;
                 Update.runAsync(true);
@@ -108,6 +110,11 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
 
 // deprecated, keeping for backward compatibility
 void AsyncElegantOtaClass::loop() {
+}
+
+void AsyncElegantOtaClass::onOTAStart(void callable(void)){
+    preUpdateCallback = callable;
+    _preUpdateRequired = true ;
 }
 
 void AsyncElegantOtaClass::restart() {

--- a/src/AsyncElegantOTA.cpp
+++ b/src/AsyncElegantOTA.cpp
@@ -95,6 +95,7 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
             if (Update.write(data, len) != len) {
                 return request->send(400, "text/plain", "OTA could not begin");
             }
+            if (_progressUpdateRequired) progressUpdateCallback();
         }
             
         if (final) { // if the final flag is set then this is the last frame of data
@@ -102,6 +103,7 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
                 Update.printError(Serial);
                 return request->send(400, "text/plain", "Could not end OTA");
             }
+            if (_postUpdateRequired) postUpdateCallback();
         }else{
             return;
         }
@@ -115,6 +117,16 @@ void AsyncElegantOtaClass::loop() {
 void AsyncElegantOtaClass::onOTAStart(void callable(void)){
     preUpdateCallback = callable;
     _preUpdateRequired = true ;
+}
+
+void AsyncElegantOtaClass::onOTAProgress(void callable(void)){
+    progressUpdateCallback= callable;
+    _progressUpdateRequired = true ;
+}
+
+void AsyncElegantOtaClass::onOTAEnd(void callable(void)){
+    postUpdateCallback = callable;
+    _postUpdateRequired = true ;
 }
 
 void AsyncElegantOtaClass::restart() {

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -33,7 +33,9 @@ class AsyncElegantOtaClass{
             setID(const char* id),
             begin(AsyncWebServer *server, const char* username = "", const char* password = ""),
             loop(),
+            onOTAStart(void callable(void)),
             restart();
+
 
     private:
         AsyncWebServer *_server;
@@ -44,7 +46,8 @@ class AsyncElegantOtaClass{
         String _username = "";
         String _password = "";
         bool _authRequired = false;
-
+        bool _preUpdateRequired = false;
+        void (*preUpdateCallback)();
 };
 
 extern AsyncElegantOtaClass AsyncElegantOTA;

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -34,6 +34,8 @@ class AsyncElegantOtaClass{
             begin(AsyncWebServer *server, const char* username = "", const char* password = ""),
             loop(),
             onOTAStart(void callable(void)),
+            onOTAProgress(void callable(void)),
+            onOTAEnd(void callable(void)),
             restart();
 
 
@@ -47,7 +49,11 @@ class AsyncElegantOtaClass{
         String _password = "";
         bool _authRequired = false;
         bool _preUpdateRequired = false;
+        bool _progressUpdateRequired = false;
+        bool _postUpdateRequired = false;
         void (*preUpdateCallback)();
+        void (*progressUpdateCallback)();
+        void (*postUpdateCallback)();
 };
 
 extern AsyncElegantOtaClass AsyncElegantOTA;


### PR DESCRIPTION
Hi,

As I needed a callback on start of OTA to save the status of my program to resume after the date I added optional interfaces to get a callback 

Prior to OTA start
On OTA progress
After OTA completed

The implementation is backward compatible to your latest release.
It doesn't require any changes to existing user that don't need any of the callback functions

The callback is only activated once you call the activation call with the correct callback function added.

PS: I also update the standard OTA library with exactly the same class extensions.
As I only have an ESP32 I couldn't test on ESP8266 but as I only added no architecture dependent code it should work out of the box.