### PR TITLE
Adding NOHTMLRENDER build flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Download the [Repository](https://github.com/ayushsharma82/AsyncElegantOTA/archi
  
  If you would like to add login to your OTA webpage, then please replace `AsyncElegantOTA.begin(&server);` with `AsyncElegantOTA.begin(&server, "username", "password");`. This will prevent unauthorized requests to your OTA webpage and prevent unauthorized firmware upload to your MCU.
  
+ If you want to disable the HTML rendering (either for security purpose or to reduce the memory space used), you can add the build flag `NOHTMLRENDER` during the build.
+
 <br>
 
 <b>Antivirus Issue:</b> If you have an antivirus on your PC with internet security, the progress bar on webpage will instantly show 100% because of request caching by your antivirus software. There is no fix for this unless you want to disable your antivirus or whitelist your local IP addresses in it. ( Same is the case with iOS, safari will cache the outgoing requests )

--- a/src/AsyncElegantOTA.cpp
+++ b/src/AsyncElegantOTA.cpp
@@ -31,7 +31,7 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
             request->send(200, "application/json", "{\"id\": \""+_id+"\", \"hardware\": \"ESP32\"}");
         #endif
     });
-
+    #ifndef NOHTMLRENDER
     _server->on("/update", HTTP_GET, [&](AsyncWebServerRequest *request){
         if(_authRequired){
             if(!request->authenticate(_username.c_str(), _password.c_str())){
@@ -42,7 +42,7 @@ void AsyncElegantOtaClass::begin(AsyncWebServer *server, const char* username, c
         response->addHeader("Content-Encoding", "gzip");
         request->send(response);
     });
-
+    #endif
     _server->on("/update", HTTP_POST, [&](AsyncWebServerRequest *request) {
         if(_authRequired){
             if(!request->authenticate(_username.c_str(), _password.c_str())){

--- a/src/AsyncElegantOTA.h
+++ b/src/AsyncElegantOTA.h
@@ -23,7 +23,9 @@
 #include "ESPAsyncWebServer.h"
 #include "FS.h"
 
+#ifndef NOHTMLRENDER
 #include "elegantWebpage.h"
+#endif
 
 
 class AsyncElegantOtaClass{


### PR DESCRIPTION
Even if it's possible to protect the upload of firmware with credentials, I would prefer to totally disable the update form, when firmware is published automatically via a script.
In addition, there would be a saving of memory space 4% on my ESP-32, due to the HTML template not loaded.

To ensure the template is not embedded within the build, the best I found is to use build flag.
Example in my platformio.ini file:
`build_flags = -D NOHTMLRENDER`

Of course, no flag = no change in the current behavior.

In the proposed readme change, I didn't include how to add a build flag, because I assume it's easy to find how to.

btw thanks a lot for this awesome lib! :)